### PR TITLE
Added support for echo based rest framework

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -4,5 +4,6 @@
     "project_human_name": null,
     "description": null,
     "docker_image_name": null,
-    "git_clone_url": null
+    "git_clone_url": null,
+    "rest_framework": ["yes", "no"]
 }

--- a/{{cookiecutter.project_name}}/cli/version.go
+++ b/{{cookiecutter.project_name}}/cli/version.go
@@ -4,6 +4,7 @@ package cli
 
 import (
 	"fmt"
+
 	"{{ cookiecutter.project_name|lower }}/config"
 
 	"github.com/spf13/cobra"

--- a/{{cookiecutter.project_name}}/cli/{% if cookiecutter.rest_framework == "yes" %}runserver.go{% endif %}
+++ b/{{cookiecutter.project_name}}/cli/{% if cookiecutter.rest_framework == "yes" %}runserver.go{% endif %}
@@ -1,0 +1,17 @@
+package cli
+
+import (
+	"{{ cookiecutter.project_name|lower }}/server"
+
+	"github.com/spf13/cobra"
+)
+
+var runserverCmd = &cobra.Command{
+	Use:   "runserver",
+	Short: "Run the user email service REST API",
+	Run: func(cmd *cobra.Command, args []string) {
+		server.Configure()
+		s := server.New()
+		server.RunServer(s)
+	},
+}

--- a/{{cookiecutter.project_name}}/cli/{{cookiecutter.project_name}}.go
+++ b/{{cookiecutter.project_name}}/cli/{{cookiecutter.project_name}}.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+
 	"{{ cookiecutter.project_name|lower }}/config"
 	"{{ cookiecutter.project_name|lower }}/logger"
 
@@ -35,6 +36,7 @@ func init() {
 	{{ cookiecutter.project_name|lower }}Cmd.PersistentFlags().StringP("verbosity", "v", "", "Log Level Verbosity (debug, info, warn, error)")
 	// Sub Commands (Add more as required)
 	{{ cookiecutter.project_name|lower }}Cmd.AddCommand(versionCmd)
+	{% if cookiecutter.rest_framework == "yes" %}{{ cookiecutter.project_name|lower }}Cmd.AddCommand(runserverCmd){% endif %}
 }
 
 // Configures static parts of the application

--- a/{{cookiecutter.project_name}}/config/{% if cookiecutter.rest_framework == "yes" %}server.go{% endif %}
+++ b/{{cookiecutter.project_name}}/config/{% if cookiecutter.rest_framework == "yes" %}server.go{% endif %}
@@ -1,0 +1,37 @@
+// Web Server Configuration
+
+package config
+
+import "github.com/spf13/viper"
+
+// Logger viper path lookup, example:
+//
+// [server]
+// bind = "127.0.0.1"
+// port = 5000
+const (
+	vServerBind = "server.bind"
+	vServerPort = "server.port"
+)
+
+type ServerConfig struct {
+	Bind string
+	Port int
+}
+
+func NewServerConfig() ServerConfig {
+	// Bind IP Address, default ""
+	if !viper.IsSet(vServerBind) {
+		viper.Set(vServerBind, "")
+	}
+
+	// Port Number, default 5000
+	if !viper.IsSet(vServerPort) {
+		viper.Set(vServerPort, 5000)
+	}
+
+	return ServerConfig{
+		Bind: viper.GetString(vServerBind),
+		Port: viper.GetInt(vServerPort),
+	}
+}

--- a/{{cookiecutter.project_name}}/config/{% if cookiecutter.rest_framework == "yes" %}server_test.go{% endif %}
+++ b/{{cookiecutter.project_name}}/config/{% if cookiecutter.rest_framework == "yes" %}server_test.go{% endif %}
@@ -1,0 +1,36 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+func TestNewServerConfig(t *testing.T) {
+	tt := []struct {
+		bind string
+		port int
+
+		expected ServerConfig
+	}{
+		{"", 0, ServerConfig{"", 5000}},
+		{"127.0.0.1", 8000, ServerConfig{"127.0.0.1", 8000}},
+	}
+
+	for _, tc := range tt {
+		if tc.bind != "" {
+			viper.Set(vServerBind, tc.bind)
+		}
+
+		if tc.port != 0 {
+			viper.Set(vServerPort, tc.port)
+		}
+
+		config := NewServerConfig()
+
+		if !reflect.DeepEqual(tc.expected, config) {
+			t.Errorf("want %#v, got %#v", tc.expected, config)
+		}
+	}
+}

--- a/{{cookiecutter.project_name}}/testutil/{% if cookiecutter.rest_framework == "yes" %}echo.go{% endif %}
+++ b/{{cookiecutter.project_name}}/testutil/{% if cookiecutter.rest_framework == "yes" %}echo.go{% endif %}
@@ -1,0 +1,41 @@
+// Test utility helpers for testing Echo web service functionality
+
+package testutil
+
+import (
+	"io"
+
+	"github.com/labstack/echo"
+	"github.com/labstack/echo/engine"
+	et "github.com/labstack/echo/test"
+)
+
+// A fake echo binder allowing us to mock a binder
+type EchoBinder struct {
+	BindF func(interface{}, echo.Context) error
+}
+
+func (b *EchoBinder) Bind(i interface{}, ctx echo.Context) error {
+	if b.BindF != nil {
+		return b.BindF(i, ctx)
+	}
+
+	return nil
+}
+
+// Constructs a new echo server, returning a request, recorder and context
+// Usage:
+// req, rec, ctx := testutil.EchoRecorder(echo.POST, "/foo", strings.NewReader("foo"), nil)
+// myFooHandler(ctx)
+// fmt.Println(rec.Body.String())
+func EchoRecorder(method, path string, body io.Reader, binder echo.Binder) (engine.Request, *et.ResponseRecorder, echo.Context) {
+	server := echo.New()
+	if binder != nil {
+		server.SetBinder(binder)
+	}
+	req := et.NewRequest(method, path, body)
+	rec := et.NewResponseRecorder()
+	ctx := server.NewContext(req, rec)
+
+	return req, rec, ctx
+}

--- a/{{cookiecutter.project_name}}/vendor/vendor.json
+++ b/{{cookiecutter.project_name}}/vendor/vendor.json
@@ -2,6 +2,186 @@
 	"comment": "{{ cookiecutter.client_name }} {{ cookiecutter.project_human_name }}",
 	"ignore": "test",
 	"package": [
+        {%- if cookiecutter.rest_framework == "yes" %}
+		{
+			"path": "context",
+			"revision": ""
+		},
+		{
+			"checksumSHA1": "39c+shSLmvturiMmkG4MjIFQQB4=",
+			"path": "github.com/davecgh/go-spew/spew",
+			"revision": "5215b55f46b2b919f50a1df0eaa5886afe4e3b3d",
+			"revisionTime": "2015-11-05T21:09:06Z"
+		},
+		{
+			"checksumSHA1": "a2yC46a1qsJomgY6rb+FkTFiqmE=",
+			"path": "github.com/davecgh/go-spew/spew/testdata",
+			"revision": "5215b55f46b2b919f50a1df0eaa5886afe4e3b3d",
+			"revisionTime": "2015-11-05T21:09:06Z"
+		},
+		{
+			"checksumSHA1": "co2ewt/AR52wp8+aosY4rP69mLo=",
+			"path": "github.com/klauspost/compress/flate",
+			"revision": "14eb9c4951195779ecfbec34431a976de7335b0a",
+			"revisionTime": "2016-04-21T08:16:54Z"
+		},
+		{
+			"checksumSHA1": "f/kBfe/7xxOGWZrpxcxd6/o9LHg=",
+			"path": "github.com/klauspost/compress/gzip",
+			"revision": "14eb9c4951195779ecfbec34431a976de7335b0a",
+			"revisionTime": "2016-04-21T08:16:54Z"
+		},
+		{
+			"checksumSHA1": "FAQCJaSqBM38fZW6M35V87+jP80=",
+			"path": "github.com/klauspost/compress/zlib",
+			"revision": "14eb9c4951195779ecfbec34431a976de7335b0a",
+			"revisionTime": "2016-04-21T08:16:54Z"
+		},
+		{
+			"checksumSHA1": "yUr1BBSD2QCISa1Jm85a4uo/Y8E=",
+			"path": "github.com/klauspost/cpuid",
+			"revision": "09cded8978dc9e80714c4d85b0322337b0a1e5e0",
+			"revisionTime": "2016-03-02T07:53:16Z"
+		},
+		{
+			"checksumSHA1": "ZnmIca9gJ7fTDBPVOaqQQl55yS0=",
+			"path": "github.com/klauspost/crc32",
+			"revision": "19b0b332c9e4516a6370a0456e6182c3b5036720",
+			"revisionTime": "2016-02-19T14:26:09Z"
+		},
+		{
+			"checksumSHA1": "gIbZ9Py/0CVhz7m88R06a+sZPQ0=",
+			"path": "github.com/labstack/echo",
+			"revision": "fbcdf70c52c155ae9aa58e72ee0532fa2f1cad2e",
+			"revisionTime": "2016-06-16T21:40:43Z",
+			"version": "v2.0.2",
+			"versionExact": "v2.0.2"
+		},
+		{
+			"checksumSHA1": "2Mz/839MjqrCexm8fj0QrpirGmg=",
+			"path": "github.com/labstack/echo/engine",
+			"revision": "fbcdf70c52c155ae9aa58e72ee0532fa2f1cad2e",
+			"revisionTime": "2016-06-16T21:40:43Z",
+			"version": "v2.0.2",
+			"versionExact": "v2.0.2"
+		},
+		{
+			"checksumSHA1": "2rfwsPUgMdgK02pvPZqpQphfKC8=",
+			"path": "github.com/labstack/echo/engine/fasthttp",
+			"revision": "fbcdf70c52c155ae9aa58e72ee0532fa2f1cad2e",
+			"revisionTime": "2016-06-16T21:40:43Z",
+			"version": "v2.0.2",
+			"versionExact": "v2.0.2"
+		},
+		{
+			"checksumSHA1": "U2RRYVpUR29BXkud88r2KmL5Co0=",
+			"path": "github.com/labstack/echo/engine/test",
+			"revision": "fbcdf70c52c155ae9aa58e72ee0532fa2f1cad2e",
+			"revisionTime": "2016-06-16T21:40:43Z",
+			"version": "v2.0.2",
+			"versionExact": "v2.0.2"
+		},
+		{
+			"checksumSHA1": "iDCjk9XfJyeiobpsw3E1UXXde/0=",
+			"path": "github.com/labstack/echo/log",
+			"revision": "fbcdf70c52c155ae9aa58e72ee0532fa2f1cad2e",
+			"revisionTime": "2016-06-16T21:40:43Z",
+			"version": "v2.0.2",
+			"versionExact": "v2.0.2"
+		},
+		{
+			"checksumSHA1": "OeDMc+lnDvXpVufkmCt28Y1mcWI=",
+			"path": "github.com/labstack/echo/test",
+			"revision": "fbcdf70c52c155ae9aa58e72ee0532fa2f1cad2e",
+			"revisionTime": "2016-06-16T21:40:43Z",
+			"version": "v2.0.2",
+			"versionExact": "v2.0.2"
+		},
+		{
+			"checksumSHA1": "0ihi3ZtoKAQge6Kyo4NsV5IahMo=",
+			"path": "github.com/labstack/gommon/color",
+			"revision": "445cf40e6de4cbef35daf3285ff5212c91e78262",
+			"revisionTime": "2016-07-19T15:51:39Z"
+		},
+		{
+			"checksumSHA1": "KFpZz0QbjTOh/gSNa13+Exz7yvU=",
+			"path": "github.com/labstack/gommon/log",
+			"revision": "445cf40e6de4cbef35daf3285ff5212c91e78262",
+			"revisionTime": "2016-07-19T15:51:39Z"
+		},
+		{
+			"checksumSHA1": "ZAlzPBSsaGe/k5pbISRQvSiVhfc=",
+			"path": "github.com/mattn/go-colorable",
+			"revision": "ed8eb9e318d7a84ce5915b495b7d35e0cfe7b5a8",
+			"revisionTime": "2016-07-31T23:54:17Z"
+		},
+		{
+			"checksumSHA1": "xZuhljnmBysJPta/lMyYmJdujCg=",
+			"path": "github.com/mattn/go-isatty",
+			"revision": "66b8e73f3f5cda9f96b69efd03dd3d7fc4a5cdb8",
+			"revisionTime": "2016-08-06T12:27:52Z"
+		},
+		{
+			"checksumSHA1": "RZOdTSZN/PgcTqko5LzIAzw+UT4=",
+			"path": "github.com/pmezard/go-difflib/difflib",
+			"revision": "792786c7400a136282c1664665ae0a8db921c6c2",
+			"revisionTime": "2016-01-10T10:55:54Z"
+		},
+		{
+			"checksumSHA1": "5mJ/wol4LCFBUct8fbQVkRJv7ZI=",
+			"path": "github.com/stretchr/testify/assert",
+			"revision": "d77da356e56a7428ad25149ca77381849a6a5232",
+			"revisionTime": "2016-06-15T09:26:46Z"
+		},
+		{
+			"checksumSHA1": "zRZE+G+b3z1jCJVAlimy1xYZxKM=",
+			"path": "github.com/valyala/bytebufferpool",
+			"revision": "8ebd0474e5a2f0a5c7a74ad2bf421a1d1a90264f",
+			"revisionTime": "2016-07-12T06:12:50Z"
+		},
+		{
+			"checksumSHA1": "qvK76gR4ULctXEKdRMU1ECTL/sg=",
+			"path": "github.com/valyala/fasthttp",
+			"revision": "45697fe30a130ec6a54426a069c82f3abe76b63d",
+			"revisionTime": "2016-07-18T15:22:57Z"
+		},
+		{
+			"checksumSHA1": "h1exupC04GjOkHEfA0RDUXW2hOk=",
+			"path": "github.com/valyala/fasthttp/fasthttputil",
+			"revision": "45697fe30a130ec6a54426a069c82f3abe76b63d",
+			"revisionTime": "2016-07-18T15:22:57Z"
+		},
+		{
+			"checksumSHA1": "jwXc0d2bZqVERG7A1q4MW/RRs9U=",
+			"path": "github.com/valyala/fasttemplate",
+			"revision": "3b874956e03f1636d171bda64b130f9135f42cff",
+			"revisionTime": "2016-03-15T19:31:34Z"
+		},
+		{
+			"checksumSHA1": "88lxkrVVZyBqOBOFnNMBwEexiLY=",
+			"path": "golang.org/x/net/context",
+			"revision": "075e191f18186a8ff2becaf64478e30f4545cdad",
+			"revisionTime": "2016-08-05T06:12:51Z"
+		},
+		{
+			"checksumSHA1": "AHhuIKGGOtr2wVEjLddGdyTzifA=",
+			"path": "golang.org/x/sys/unix",
+			"revision": "a646d33e2ee3172a661fc09bca23bb4889a41bc8",
+			"revisionTime": "2016-07-15T05:43:45Z"
+		},
+		{
+			"checksumSHA1": "Dcg4qrljkDxJc6nMG2coIGmEXKs=",
+			"path": "github.com/asaskevich/govalidator",
+			"revision": "593d64559f7600f29581a3ee42177f5dbded27a9",
+			"revisionTime": "2016-07-15T17:06:12Z"
+		},
+		{
+			"checksumSHA1": "BpLPxpgxWsmjEVo6Lzm71mq0xIE=",
+			"path": "github.com/nvellon/hal",
+			"revision": "08af269b06ba828cf9b3177a3667b8c868269f3d",
+			"revisionTime": "2016-05-03T04:38:58Z"
+		},
+        {% endif %}
 		{
 			"checksumSHA1": "hqDDDpue/5363luidNMBS8z8eJU=",
 			"path": "github.com/BurntSushi/toml",

--- a/{{cookiecutter.project_name}}/{% if cookiecutter.rest_framework == "yes" %}hal{% endif %}/error.go
+++ b/{{cookiecutter.project_name}}/{% if cookiecutter.rest_framework == "yes" %}hal{% endif %}/error.go
@@ -1,0 +1,99 @@
+// Common HAL Formatted Error Handlers
+
+package hal
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+
+	"github.com/asaskevich/govalidator"
+	"github.com/nvellon/hal"
+)
+
+// Common 500 error response
+var EDefaultError = &Error{
+	Message: "An unexpected error has occured",
+}
+
+// Common 404 error response
+var ENotFound = &Error{
+	Message: "This is not the resource you are looking for",
+}
+
+// This type allows us to produce a map of specifc errors, this
+// is useful for validation error messages for example where we
+// need to list errors field by field
+type ErrorMap map[string]string
+
+func (m ErrorMap) Add(field string, err error) {
+	m[field] = err.Error()
+}
+
+func (m ErrorMap) Delete(field string) {
+	delete(m, field)
+}
+
+// A HAL error type that satisfies the nvellon/hal mapper interface
+// and the standard go error interface, this allows us to produce
+// hal formatted error responses
+type Error struct {
+	Message  string   `json:"message"`
+	ErrorMap ErrorMap `json:"errors,omitempty"`
+}
+
+func (e *Error) Error() string {
+	return e.Message
+}
+
+func (e *Error) GetMap() hal.Entry {
+	return hal.Entry{"_errors": e}
+}
+
+// Constructs an ErrorMap from govalidator validation errors, if json tags also exist
+// the error map will be populated with the json field name instead of the struct field name
+func ValidationErrorMap(i interface{}, err error) ErrorMap {
+	// Ensure we have a govalidator error
+	err, ok := err.(govalidator.Errors)
+	if !ok {
+		return nil
+	}
+
+	// Use refect to get the raw struct element
+	typ := reflect.TypeOf(i).Elem()
+	if typ.Kind() != reflect.Struct {
+		return nil
+	}
+
+	// Errors found by the validator
+	errsByField := govalidator.ErrorsByField(err.(govalidator.Errors))
+
+	// Make an error map
+	m := make(ErrorMap, len(errsByField))
+
+	// Loop over our struct fields
+	for i := 0; i < typ.NumField(); i++ {
+		// Get the field
+		f := typ.Field(i)
+		// Do we have an error for the field
+		e, ok := errsByField[f.Name]
+		if ok {
+			// Try and get the `json` struct tag
+			name := strings.Split(f.Tag.Get("json"), ",")[0]
+			// If the name is - we should ignore the field
+			if name == "-" {
+				continue
+			}
+			// If the name is not blank we add it our error map
+			if name != "" {
+				m.Add(name, errors.New(e))
+				continue
+			}
+			// Finall if all else has failed just add the raw field name to the
+			// error map
+			m.Add(f.Name, errors.New(e))
+		}
+	}
+
+	return m
+}

--- a/{{cookiecutter.project_name}}/{% if cookiecutter.rest_framework == "yes" %}hal{% endif %}/hal.go
+++ b/{{cookiecutter.project_name}}/{% if cookiecutter.rest_framework == "yes" %}hal{% endif %}/hal.go
@@ -1,0 +1,46 @@
+package hal
+
+import (
+	"net/http"
+
+	"{{ cookiecutter.project_name|lower }}/logger"
+
+	"github.com/asaskevich/govalidator"
+	"github.com/labstack/echo"
+	"github.com/nvellon/hal"
+)
+
+// Returns a hal formatted response
+func Response(status int, ctx echo.Context, r *hal.Resource) error {
+	return ctx.JSON(status, r)
+}
+
+// Builds a HAL resource doucment from request context
+func Resource(ctx echo.Context, i interface{}) *hal.Resource {
+	return hal.NewResource(i, ctx.Request().URI())
+}
+
+// Common 500 error handler, logging the error
+func ServerError(ctx echo.Context, err error) error {
+	logger.Error("%#v", err)
+	r := Resource(ctx, EDefaultError)
+	return Response(http.StatusInternalServerError, ctx, r)
+}
+
+// Common 404 handler
+func NotFound(ctx echo.Context) error {
+	return Response(http.StatusNotFound, ctx, Resource(ctx, ENotFound))
+}
+
+// Common Validation Error handler
+func ValidationError(ctx echo.Context, i interface{}, err error) error {
+	_, ok := err.(govalidator.Errors)
+	if !ok {
+		return Response(422, ctx, Resource(ctx, &Error{Message: err.Error()}))
+	}
+
+	return Response(422, ctx, Resource(ctx, &Error{
+		Message:  "Validation Error",
+		ErrorMap: ValidationErrorMap(i, err),
+	}))
+}

--- a/{{cookiecutter.project_name}}/{% if cookiecutter.rest_framework == "yes" %}server{% endif %}/handlers.go
+++ b/{{cookiecutter.project_name}}/{% if cookiecutter.rest_framework == "yes" %}server{% endif %}/handlers.go
@@ -1,0 +1,24 @@
+// Default HTTP Handlers serving common routes
+
+package server
+
+import (
+	"net/http"
+
+	"{{ cookiecutter.project_name|lower }}/config"
+	"{{ cookiecutter.project_name|lower }}/hal"
+
+	"github.com/labstack/echo"
+)
+
+// GET /__healthcheck__
+// The Healthcheck endpoint returns the current version with a 200 response
+func healthcheckHandler(ctx echo.Context) error {
+	r := hal.Resource(ctx, struct {
+		Version string `json:"version"`
+	}{
+		Version: config.Version(),
+	})
+
+	return hal.Response(http.StatusOK, ctx, r)
+}

--- a/{{cookiecutter.project_name}}/{% if cookiecutter.rest_framework == "yes" %}server{% endif %}/handlers_test.go
+++ b/{{cookiecutter.project_name}}/{% if cookiecutter.rest_framework == "yes" %}server{% endif %}/handlers_test.go
@@ -1,0 +1,26 @@
+package server
+
+import (
+	"testing"
+
+	"{{ cookiecutter.project_name|lower }}/testutil"
+
+	"github.com/labstack/echo"
+)
+
+func TestHelathcheckHandler(t *testing.T) {
+	tt := []struct {
+		expected string
+	}{
+		{`{"_links":{"self":{"href":"/__healthcheck__"}},"version":"unknown"}`},
+	}
+
+	for _, tc := range tt {
+		_, rec, ctx := testutil.EchoRecorder(echo.GET, "/__healthcheck__", nil, nil)
+		healthcheckHandler(ctx)
+
+		if tc.expected != rec.Body.String() {
+			t.Errorf("wanted %s got %s", tc.expected, rec.Body.String())
+		}
+	}
+}

--- a/{{cookiecutter.project_name}}/{% if cookiecutter.rest_framework == "yes" %}server{% endif %}/server.go
+++ b/{{cookiecutter.project_name}}/{% if cookiecutter.rest_framework == "yes" %}server{% endif %}/server.go
@@ -1,0 +1,58 @@
+// Echo Server
+
+package server
+
+import (
+	"fmt"
+	"net/http"
+
+	"{{ cookiecutter.project_name|lower }}/config"
+	"{{ cookiecutter.project_name|lower }}/hal"
+	"{{ cookiecutter.project_name|lower }}/logger"
+
+	"github.com/labstack/echo"
+	"github.com/labstack/echo/engine/fasthttp"
+)
+
+// Configuration
+var c config.ServerConfig
+
+// Always initialise an Echo instance
+func New() *echo.Echo {
+	server := echo.New()
+	// Add healthcheck handler
+	server.GET("/__healthcheck__", healthcheckHandler)
+	// Set default error handler
+	server.SetHTTPErrorHandler(errorHandler)
+
+	return server
+}
+
+func RunServer(server *echo.Echo) {
+	// Runs the web service
+	logger.Fields(logger.F{"config": c}).Info("Starting Web Server")
+	server.Run(fasthttp.New(fmt.Sprintf("%s:%d", c.Bind, c.Port)))
+}
+
+// Updates the c variable with configuration
+func Configure() {
+	c = config.NewServerConfig()
+}
+
+// Common error handler func that returns proper formatted HAL documents
+func errorHandler(err error, ctx echo.Context) {
+	code := http.StatusInternalServerError
+	msg := http.StatusText(code)
+	if he, ok := err.(*echo.HTTPError); ok {
+		code = he.Code
+		msg = he.Message
+	}
+	switch code {
+	case http.StatusNotFound:
+		hal.NotFound(ctx)
+	case http.StatusInternalServerError:
+		hal.ServerError(ctx, err)
+	default:
+		hal.Response(code, ctx, hal.Resource(ctx, &hal.Error{Message: msg}))
+	}
+}


### PR DESCRIPTION
This PR adds a new `rest_framework` option with options being "yes", or "no".

If "yes" (default) is chosen then all of requirements and added to run an echo based hal formatted rest web service.
