### PR TITLE
Fix: Do not render the vendor directory

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -7,5 +7,9 @@
     "go_version": "1.8",
     "alpine_version": "3.5",
     "onbuild_pkgs": "",
-    "local_config_path": ""
+    "local_config_path": "",
+
+    "_copy_without_render": [
+        "*vendor"
+    ]
 }


### PR DESCRIPTION
This PR adds a new `_copy_without_render` config option to the cookie cutter file which will ensure the vendor directory will not be rendered when cookie cutter processes the template.

Fixes #6 