### PR TITLE
Fix: Move build into separate package

### DIFF
--- a/{{cookiecutter.project_name}}/build/build.go
+++ b/{{cookiecutter.project_name}}/build/build.go
@@ -1,4 +1,4 @@
-package app
+package build
 
 import (
 	"strconv"

--- a/{{cookiecutter.project_name}}/cli/root.go
+++ b/{{cookiecutter.project_name}}/cli/root.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"{{cookiecutter.project_name}}/app"
+	"{{cookiecutter.project_name}}/build"
 	"{{cookiecutter.project_name}}/config"
 	"{{cookiecutter.project_name}}/log"
 
@@ -35,8 +36,8 @@ var rootCmd = &cobra.Command{
 		})
 		// Always log these fields
 		l.PersistentFields(logrus.Fields{
-			"version":   app.Version(),
-			"buildTime": app.BuildTime(),
+			"version":   build.Version(),
+			"buildTime": build.BuildTime(),
 		})
 		// Set global logger
 		log.SetGlobalLogger(l)

--- a/{{cookiecutter.project_name}}/cli/version.go
+++ b/{{cookiecutter.project_name}}/cli/version.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"fmt"
 
-	"{{cookiecutter.project_name}}/app"
+	"{{cookiecutter.project_name}}/build"
 
 	"github.com/spf13/cobra"
 )
@@ -14,8 +14,8 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print application version and build time",
 	Run: func(*cobra.Command, []string) {
-		bt := app.BuildTime().Format("Monday January 2 2006 at 15:04:05 MST")
-		fmt.Println(fmt.Sprintf("Version: %s", app.Version()))
+		bt := build.BuildTime().Format("Monday January 2 2006 at 15:04:05 MST")
+		fmt.Println(fmt.Sprintf("Version: %s", build.Version()))
 		fmt.Println(fmt.Sprintf("Build Time: %s", bt))
 	},
 }


### PR DESCRIPTION
Moving build to separate package to flatten structure and avoid cyclic import situations with the app package.