### PR TITLE
fix(cmd): Disable cobra error logging

### DIFF
--- a/{{cookiecutter.name}}/cmd/{{cookiecutter.name}}/main.go
+++ b/{{cookiecutter.name}}/cmd/{{cookiecutter.name}}/main.go
@@ -34,6 +34,8 @@ func {{cookiecutter.name|replace('-', '')|replace('.', '')}}Cmd() *cobra.Command
 	cmd := &cobra.Command{
 		Use:   "{{cookiecutter.name}}",
 		Short: "Run the service",
+		SilenceErrors: true,
+		SilenceUsage:  true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			// Load config
 			var err error


### PR DESCRIPTION
Disabling cobra error logging as we are already logging them with our custom logger at the main entrypoint. At the moment fatal errors (those returned from RunE or PersistentPreRunE) would be logged twice.