### PR TITLE
build(docker): Pass-through GOPROXY env var

### DIFF
--- a/{{cookiecutter.name}}/Makefile
+++ b/{{cookiecutter.name}}/Makefile
@@ -81,6 +81,7 @@ image:
 		--build-arg GIT_SHA=$(GIT_SHA) \
 		--build-arg GIT_TAG=$(GIT_TAG) \
 		--build-arg GIT_DIRTY=$(GIT_DIRTY) \
+		--build-arg GOPROXY \
 		-f ./build/package/Dockerfile \
 		-t $(DOCKER_REGISTRY):$(DOCKER_TAG) .
 {% endif %}

--- a/{{cookiecutter.name}}/build/package/Dockerfile
+++ b/{{cookiecutter.name}}/build/package/Dockerfile
@@ -6,6 +6,8 @@ ARG GIT_COMMIT
 ARG GIT_SHA
 ARG GIT_TAG
 ARG GIT_DIRTY
+ARG GOPROXY
+ENV GOPROXY=$GOPROXY
 ENV BIN_OUTDIR=./
 ENV BIN_NAME={{cookiecutter.name}}
 RUN apk update && apk add build-base git libressl-dev


### PR DESCRIPTION
Adds support for passing through the GOPROXY env var to the docker build stage, this enables utilising a go modules proxy in the docker build stage.