### PR TITLE
build(Makefile): Default test run with race detector

### DIFF
--- a/{{cookiecutter.name}}/Makefile
+++ b/{{cookiecutter.name}}/Makefile
@@ -92,4 +92,4 @@ test:
 ifeq ("$(wildcard $(shell which gocov))","")
 	go get github.com/axw/gocov/gocov
 endif
-	gocov test ${PKG_LIST} | gocov report
+	gocov test -race ${PKG_LIST} | gocov report

--- a/{{cookiecutter.name}}/build/ci/.gitlab-ci.yml
+++ b/{{cookiecutter.name}}/build/ci/.gitlab-ci.yml
@@ -34,7 +34,7 @@ before_script:
 # Runs tests in a go image
 test:
   stage: test
-  image: golang:{{cookiecutter.go}}-alpine
+  image: golang:{{cookiecutter.go}}-stretch # using debian to support go race detector
   script:
     - apk update && apk add make build-base git
     - make test


### PR DESCRIPTION
Updated make test to use race detector by default. Also changed CI stage to run debian as the race detector is not supported on alpine.