### PR TITLE
fix(makefile): Stop static build from logging output

### DIFF
--- a/{{cookiecutter.name}}/Makefile
+++ b/{{cookiecutter.name}}/Makefile
@@ -54,7 +54,7 @@ static: CGO = 0
 static: GOBUILDFLAGS += -a
 static: GOBUILDFLAGS += -tags netgo -installsuffix netgo
 static: GOBUILDFLAGS += -installsuffix netgo
-static: LDFLAGS += -a -extldflags "-static"
+static: LDFLAGS += -extldflags "-static"
 static: build
 
 # Build a binary


### PR DESCRIPTION
Running `make static` was outputting assembly to the console. This was caused the by the `-a` flag passed to go tool link in `-ldflags`. From the [go tool link docs](https://golang.org/cmd/link/#:~:text=Command%20link&text=Link%2C%20typically%20invoked%20as%20%E2%80%9Cgo,them%20into%20an%20executable%20binary):
> -a Disassemble output.
Removing this as it is not required.